### PR TITLE
Remove duplicate of uid.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,5 @@ COPY dynamixel_hardware src/dynamixel_hardware
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && colcon build --symlink-install --event-handlers console_direct+
 
 RUN echo 'alias build="colcon build --symlink-install  --event-handlers console_direct+"' >> ~/.bashrc
-RUN echo 'source /opt/ros/iron/setup.bash; source /colcon_ws/install/setup.bash; ros2 launch helix_bringup helix_bringup.launch.py' >> /run.sh && chmod +x /run.sh
-RUN echo 'alias run="su - ros /run.sh"' >> /etc/bash.bashrc
+RUN echo 'source /opt/ros/iron/setup.bash; source /colcon_ws/install/setup.bash; echo UID: $UID; echo ROS_DOMAIN_ID: $ROS_DOMAIN_ID; ros2 launch helix_bringup helix_bringup.launch.py' >> /run.sh && chmod +x /run.sh
+RUN echo 'alias run="su - ros --whitelist-environment=\"ROS_DOMAIN_ID\" /run.sh"' >> /etc/bash.bashrc

--- a/ros_entrypoint.sh
+++ b/ros_entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-id -u ros &>/dev/null || adduser --quiet --disabled-password --gecos '' --uid ${UID:=1000} --uid ${GID:=1000} ros
+id -u ros &>/dev/null || adduser --quiet --disabled-password --gecos '' --uid ${UID:=1003} ros
 
 source /opt/ros/${ROS_DISTRO}/setup.bash
 

--- a/ros_entrypoint.sh
+++ b/ros_entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-id -u ros &>/dev/null || adduser --quiet --disabled-password --gecos '' --uid ${UID:=1003} ros
+id -u ros &>/dev/null || adduser --quiet --disabled-password --gecos '' --uid ${UID:=1000} ros
 
 source /opt/ros/${ROS_DISTRO}/setup.bash
 

--- a/run.sh
+++ b/run.sh
@@ -6,8 +6,8 @@ docker run -it --rm \
 --network=host \
 --ipc=host \
 --pid=host \
---env UID=$(id -u) \
---env GID=$(id -g) \
+--env UID \
+--env ROS_DOMAIN_ID \
 --privileged \
 --volume ./helix_bringup:/colcon_ws/src/helix_bringup \
 --volume ./helix_description:/colcon_ws/src/helix_description \

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ docker run -it --rm \
 --network=host \
 --ipc=host \
 --pid=host \
---env UID \
+--env UID=${MY_UID} \
 --env ROS_DOMAIN_ID \
 --privileged \
 --volume ./helix_bringup:/colcon_ws/src/helix_bringup \


### PR DESCRIPTION
--whitelist-environment=\"ROS_DOMAIN_ID\" to take the ROS_DOMAIN_ID from the root shell into the ros users shell so ROS nodes started by the ros user will start them in the right domain.

echo uid and rosdomainid for better understanding

Removes duplicat of --uid definition in ros_entrypoint.sh