### PR TITLE
Change container mode to never restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    restart: always
+    restart: "no"
     network_mode: "host"
     privileged: true
     ipc: host


### PR DESCRIPTION
If something like a memory leak is introduced while developing, the computer (especially Pi) can lock up. If the container automatically restarts after rebooting, there is a race to shut it down before the computer locks up again.