### PR TITLE
Seb/change config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The `helix_transmission` package provides an interface for commanding the tendon
 - Command tendon contraction/relaxation with consistent sign (convert the motor orientation)
 - Allow for setting a tendon 'zero' position and using this as the command reference (calibrate motor positions)
 
-Relevant parameters are stored in a config file on the host Pi, in `~/.config/helix/helix_transmission.config.yml`. These can be modified locally for the specific robot, eg if the motor orientations or pulley size changes. Note: currently `~/.config/helix` needs to be created on the Pi before first launching the container, to avoid issues with permissions after mounting the volume. A default `helix_transmission.config.yml` will be created when launching the container in the case that it doesn't exist yet.
+Relevant parameters are stored in a config file on the host Pi, in `~/.config/helix/helix_transmission.config.yml`. These can be modified locally for the specific robot, eg if the motor orientations or pulley size changes. Note: currently `~/.config/helix/` needs to be created on the Pi before first launching the container, to avoid issues with permissions after mounting the volume. A default `helix_transmission.config.yml` will be created when launching the container in the case that it doesn't exist yet.
 
 Using the interface is done through topics and services in the namespace `/tendon_transmission_node/`. See [this script](https://github.com/fstella97/HelixRobotics/blob/main/ROS/roslibpy_service_test.py) for an example of listing these, and calling a service through roslibpy.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The `helix_transmission` package provides an interface for commanding the tendon
 - Command tendon contraction/relaxation with consistent sign (convert the motor orientation)
 - Allow for setting a tendon 'zero' position and using this as the command reference (calibrate motor positions)
 
-Relevant parameters are stored in a config file on the host Pi, in `~/.config/helix_transmission.config.yml`. These can be modified locally for the specific robot, eg if the motor orientations or pulley size changes. Note: currently `~/.config/` needs to be created on the Pi before first launching the container, to avoid issues with permissions after mounting the volume. A default `helix_transmission.config.yml` will be created when launching the container in the case that it doesn't exist yet.
+Relevant parameters are stored in a config file on the host Pi, in `~/.config/helix/helix_transmission.config.yml`. These can be modified locally for the specific robot, eg if the motor orientations or pulley size changes. Note: currently `~/.config/helix` needs to be created on the Pi before first launching the container, to avoid issues with permissions after mounting the volume. A default `helix_transmission.config.yml` will be created when launching the container in the case that it doesn't exist yet.
 
 Using the interface is done through topics and services in the namespace `/tendon_transmission_node/`. See [this script](https://github.com/fstella97/HelixRobotics/blob/main/ROS/roslibpy_service_test.py) for an example of listing these, and calling a service through roslibpy.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,5 @@ services:
       - UID=${HOST_UID}
       - ROS_DOMAIN_ID
     volumes:
-      - ~/.config:/tmp/config
+      - ~/.config/helix:/tmp/config
     command: su - ros --whitelist-environment=ROS_DOMAIN_ID /run.sh

--- a/helix_bringup/launch/helix_bringup.launch.py
+++ b/helix_bringup/launch/helix_bringup.launch.py
@@ -79,14 +79,11 @@ def generate_launch_description():
             output="screen",
     )
 
-    helix_transmission_params = os.path.join(get_package_share_directory('helix_transmission'),'config','helix_transmission.config.yml')
-
     tendon_transmission_node = Node(
         package="helix_transmission",
         executable="tendon_transmission_node",
         name="tendon_transmission_node",
         output="screen",
-        parameters = [helix_transmission_params],
     )
 
     ld.add_action(robot_state_publisher)


### PR DESCRIPTION
Save the config in ~/.config/helix/ instead of ~/.config, to avoid mounting the whole user config dir